### PR TITLE
Improve activation validation to mirror original logic

### DIFF
--- a/refactored/ActivationValidator.java
+++ b/refactored/ActivationValidator.java
@@ -3,12 +3,16 @@ package az;
 import java.util.Date;
 
 /**
- * Minimal activation validator used by the refactored dialog.  The original
- * project performed extensive hardware checks.  Here we simply ensure the
- * activation has not expired.
+ * Validates activation responses returned by the activation server. The
+ * original application performed extensive hardware checks; this
+ * implementation mirrors the observed behaviour from the obfuscated
+ * code sufficiently for offline activation.
  */
 public class ActivationValidator {
     private static final ActivationValidator INSTANCE = new ActivationValidator();
+
+    /** Local identifiers taken from the activation request. */
+    private ActivationRequest localRequest;
 
     public static ActivationValidator getInstance() {
         return INSTANCE;
@@ -18,17 +22,78 @@ public class ActivationValidator {
     }
 
     /**
+     * Set the identifiers used when validating activation data.
+     */
+    public void setLocalRequest(ActivationRequest request) {
+        this.localRequest = request;
+    }
+
+    /**
      * Validate the provided activation data.
      */
     public ActivationResult validate(ActivationData data) {
         ActivationResult result = new ActivationResult();
-        if (data.getRenewalDate().before(new Date())) {
-            result.setCode(2);
-            result.setMessage("Invalid activation data.");
-        } else {
-            result.setCode(0);
+        if (data == null) {
+            return result; // defaults to invalid activation data
+        }
+
+        int errorCode = data.getErrorCode();
+        if (errorCode == 0 || errorCode == 1) {
+            if (localRequest == null) {
+                result.setCode(4);
+                result.setMessage("No identifiers available.");
+                return result;
+            }
+
+            boolean haveId = false;
+            boolean match = false;
+
+            String hw = localRequest.getHardwareId();
+            if (hw != null && !hw.isEmpty()) {
+                haveId = true;
+                match = hw.equals(data.getHardwareId());
+            }
+
+            String mb = localRequest.getMotherboardId();
+            if (!match && mb != null && !mb.isEmpty()) {
+                haveId = true;
+                match = mb.equals(data.getMotherboardId());
+            }
+
+            String dev = localRequest.getDeviceId();
+            if (!match && dev != null && !dev.isEmpty()) {
+                haveId = true;
+                match = dev.equals(data.getDeviceId());
+            }
+
+            if (!haveId) {
+                result.setCode(4);
+                result.setMessage("No identifiers available.");
+                return result;
+            }
+            if (!match) {
+                result.setCode(2);
+                result.setMessage("Invalid Activation.");
+                return result;
+            }
+
+            if (data.getRenewalDate().before(new Date())) {
+                result.setCode(1);
+            } else {
+                result.setCode(0);
+            }
             result.setMessage("Valid Activation.");
             result.setData(data);
+        } else if (errorCode == 5) {
+            result.setCode(5);
+            result.setMessage("Current Activation Count: " + data.getActivationCount());
+            result.setData(data);
+        } else if (errorCode == 6) {
+            result.setCode(6);
+            result.setMessage(data.getMessage());
+        } else {
+            result.setCode(2);
+            result.setMessage("Invalid activation data.");
         }
         return result;
     }

--- a/refactored/OfflineActivationDialog.java
+++ b/refactored/OfflineActivationDialog.java
@@ -63,6 +63,7 @@ public class OfflineActivationDialog extends JDialog implements ClipboardOwner {
         this.i18n = i18n;
         this.activationRequest = request;
         this.appInfo = appInfo;
+        ActivationValidator.getInstance().setLocalRequest(request);
         buildUi();
     }
 

--- a/refactored/OfflineActivationValidation.md
+++ b/refactored/OfflineActivationValidation.md
@@ -16,17 +16,23 @@ String requestCode = request.toBase64();
 Upload `ActivationRequest.txt` to <http://www.efianalytics.com/activate> or another authorised activation server. The server returns a `ActivationCode.txt` file which contains a Base64 encoded response.
 
 ## 3. Validate the activation
-Back on the offline machine, load the contents of `ActivationCode.txt` into the dialog.  The text is parsed into an `ActivationData` instance and passed to `ActivationValidator` for basic checks.
+Back on the offline machine, load the contents of `ActivationCode.txt` into the dialog. The text is parsed into an `ActivationData`
+instance. Before validation, supply the original `ActivationRequest` so that the validator can compare hardware identifiers.
 
 ```java
 ActivationData data = new ActivationData(codeFromServer);
-ActivationResult result = ActivationValidator.getInstance().validate(data);
+ActivationValidator validator = ActivationValidator.getInstance();
+validator.setLocalRequest(request);
+ActivationResult result = validator.validate(data);
 ```
 
-`ActivationValidator` currently performs a minimal verification: it confirms that the renewal date embedded in the code has not passed.  If the validation succeeds, the activation data is accepted and stored for later use.
+`ActivationValidator` mirrors the behaviour of the original obfuscated code: it verifies that at least one hardware identifier in
+the activation matches the local request, checks the renewal date and interprets server error codes. When the identifiers match
+and the code has not expired, the activation data is accepted and stored for later use.
 
 ## 4. Common error messages
 * **Invalid activation data** – the response could not be parsed or failed validation.
+* **No identifiers available** – the activation request lacked usable identifiers.
 * **This Activation code has expired** – the renewal date is in the past; request a new code from the activation server.
 
 ## 5. Completing the process


### PR DESCRIPTION
## Summary
- enhance `ActivationValidator` to mirror obfuscated logic: compare hardware IDs, interpret server error codes and handle expiry
- wire `OfflineActivationDialog` to supply the local activation request for validation
- document updated validation flow and common error messages

## Testing
- `gradle test` *(fails: invalid tokens in original obfuscated sources)*

------
https://chatgpt.com/codex/tasks/task_e_6892abb659988329b1b09b741cb04ae3